### PR TITLE
[refactor] 프론트에서 닉네임 저장하도록 Response Dto 로직 개선 

### DIFF
--- a/src/main/java/com/moyobab/server/auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/moyobab/server/auth/dto/TokenResponseDto.java
@@ -1,5 +1,6 @@
 package com.moyobab.server.auth.dto;
 
+import com.moyobab.server.user.dto.UserResponseDto;
 import lombok.*;
 
 @Getter
@@ -10,4 +11,5 @@ import lombok.*;
 public class TokenResponseDto {
     private String accessToken;
     private String refreshToken;
+    private UserResponseDto user;
 }

--- a/src/main/java/com/moyobab/server/auth/mapper/AuthMapper.java
+++ b/src/main/java/com/moyobab/server/auth/mapper/AuthMapper.java
@@ -2,6 +2,7 @@ package com.moyobab.server.auth.mapper;
 
 import com.moyobab.server.auth.dto.TokenResponseDto;
 import com.moyobab.server.auth.entity.RefreshToken;
+import com.moyobab.server.user.dto.UserResponseDto;
 
 public class AuthMapper {
 

--- a/src/main/java/com/moyobab/server/auth/mapper/AuthMapper.java
+++ b/src/main/java/com/moyobab/server/auth/mapper/AuthMapper.java
@@ -3,10 +3,24 @@ package com.moyobab.server.auth.mapper;
 import com.moyobab.server.auth.dto.TokenResponseDto;
 import com.moyobab.server.auth.entity.RefreshToken;
 import com.moyobab.server.user.dto.UserResponseDto;
+import com.moyobab.server.user.entity.User;
 
 public class AuthMapper {
 
-    // Entity에서 DTO
+    public static TokenResponseDto toTokenResponse(String accessToken, String refreshToken, User user) {
+        return TokenResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .user(UserResponseDto.builder()
+                        .userId(user.getId())
+                        .email(user.getEmail())
+                        .nickname(user.getNickname())
+                        .build())
+                .build();
+    }
+
+
+    // 리프레시 재발급용
     public static TokenResponseDto toTokenResponse(String accessToken, String refreshToken) {
         return TokenResponseDto.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/moyobab/server/auth/service/AuthService.java
+++ b/src/main/java/com/moyobab/server/auth/service/AuthService.java
@@ -42,7 +42,7 @@ public class AuthService {
         RefreshToken newToken = AuthMapper.toRefreshToken(user.getId(), refreshToken, expiry);
         refreshTokenRepository.save(newToken);
 
-        return AuthMapper.toTokenResponse(accessToken, refreshToken);
+        return AuthMapper.toTokenResponse(accessToken, refreshToken, user);
     }
 
     // Refresh Token을 통해 Access Token 재발급

--- a/src/main/java/com/moyobab/server/user/dto/UserSignUpRequestDto.java
+++ b/src/main/java/com/moyobab/server/user/dto/UserSignUpRequestDto.java
@@ -34,6 +34,7 @@ public class UserSignUpRequestDto {
 
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     @JsonFormat(pattern = "yyyy-MM-dd")
+    @NotNull(message = "생년월일은 필수입니다.")
     private LocalDate birthDate;
 
     private String phoneNumber;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #11 

## 📝 작업 내용

1. 프론트에 내려주는 Dto에 닉네임도 추가하여 프론트에서 닉네임 저장 및 활용할수 있도록 로직 수정
2. 생년월일 필수로 변경
3. 닉네임 추가에 따라 Dto 및 Mapper 개선 

## 🖼️ 스크린샷 (선택)

> UI 변경 등 시각적으로 확인할 수 있는 내용이 있다면 첨부해주세요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 로그인 성공 시 토큰 응답에 사용자 정보가 함께 반환됩니다(예: 사용자 ID, 이메일, 닉네임). 클라이언트는 추가 조회 없이 즉시 프로필 정보를 사용할 수 있습니다.
  * 회원가입 시 생년월일 입력이 필수로 검증됩니다. 미입력 시 "생년월일은 필수입니다." 메시지와 함께 요청이 거절됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->