### PR TITLE
[refactor] Refresh Token DB 저장 -> Redis 저장 방식으로 변경 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 application.yml
 application-test.yml
+application-docker.yml

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ out/
 ### VS Code ###
 .vscode/
 
+.env
+
 application.yml
 application-test.yml
 application-docker.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,10 @@ RUN apt-get update && \
     wget -O /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
     chmod +x /usr/local/bin/wait-for-it.sh
 
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} app.jar
+WORKDIR /app
+
+COPY build/libs/server-0.0.1-SNAPSHOT.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["/usr/local/bin/wait-for-it.sh", "redis:6379", "--", "java", "-jar", "app.jar"]
+ENTRYPOINT ["/usr/local/bin/wait-for-it.sh", "mysql:3306", "--timeout=60", "--", "/usr/local/bin/wait-for-it.sh", "redis:6379", "--", "java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:21-jdk-slim
+
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget -O /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
+    chmod +x /usr/local/bin/wait-for-it.sh
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/wait-for-it.sh", "redis:6379", "--", "java", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,10 @@ services:
       - "8080:8080"
     depends_on:
       - redis
+      - mysql
     environment:
       SPRING_PROFILES_ACTIVE: docker
+      SPRING_CONFIG_LOCATION: classpath:/application-docker.yml
       TZ: Asia/Seoul
       JAVA_TOOL_OPTIONS: -Duser.timezone=Asia/Seoul
     volumes:
@@ -26,5 +28,18 @@ services:
       - redis-data:/data
     restart: unless-stopped
 
+  mysql:
+    image: mysql:8.0
+    container_name: moyobab-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    ports:
+      - "3307:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+
 volumes:
   redis-data:
+  mysql-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: moyobab-app
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      TZ: Asia/Seoul
+      JAVA_TOOL_OPTIONS: -Duser.timezone=Asia/Seoul
+    volumes:
+      - ./logs:/app/logs
+
+  redis:
+    image: redis:7.2
+    container_name: moyobab-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    restart: unless-stopped
+
+volumes:
+  redis-data:

--- a/src/main/java/com/moyobab/server/auth/service/redis/RefreshTokenRedisService.java
+++ b/src/main/java/com/moyobab/server/auth/service/redis/RefreshTokenRedisService.java
@@ -1,0 +1,37 @@
+package com.moyobab.server.auth.service.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenRedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String PREFIX = "refreshToken:";
+
+    public void save(Long userId, String refreshToken, long expiryMillis) {
+        String key = PREFIX + userId;
+        redisTemplate.opsForValue().set(
+                key,
+                refreshToken,
+                Duration.ofMillis(expiryMillis)
+        );
+    }
+
+    public String get(Long userId) {
+        return redisTemplate.opsForValue().get(PREFIX + userId);
+    }
+
+    public void delete(Long userId) {
+        redisTemplate.delete(PREFIX + userId);
+    }
+
+    public boolean isSame(Long userId, String refreshToken) {
+        String saved = get(userId);
+        return saved != null && saved.equals(refreshToken);
+    }
+}

--- a/src/main/java/com/moyobab/server/auth/service/redis/RefreshTokenRedisService.java
+++ b/src/main/java/com/moyobab/server/auth/service/redis/RefreshTokenRedisService.java
@@ -13,12 +13,18 @@ public class RefreshTokenRedisService {
     private final RedisTemplate<String, String> redisTemplate;
     private static final String PREFIX = "refreshToken:";
 
-    public void save(Long userId, String refreshToken, long expiryMillis) {
+    public void save(Long userId, String refreshToken, long ttlMillis) {
         String key = PREFIX + userId;
+
+        if (ttlMillis <= 0) {
+            redisTemplate.delete(key);
+            return;
+        }
+
         redisTemplate.opsForValue().set(
                 key,
                 refreshToken,
-                Duration.ofMillis(expiryMillis)
+                Duration.ofMillis(ttlMillis)
         );
     }
 

--- a/src/main/java/com/moyobab/server/global/config/RedisConfig.java
+++ b/src/main/java/com/moyobab/server/global/config/RedisConfig.java
@@ -3,6 +3,7 @@ package com.moyobab.server.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -34,6 +35,7 @@ public class RedisConfig {
 
     // RedisTemplate 설정 (Key: String, Value: String 기준으로)
     @Bean
+    @Primary
     public RedisTemplate<String, String> redisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());

--- a/src/main/java/com/moyobab/server/global/config/RedisConfig.java
+++ b/src/main/java/com/moyobab/server/global/config/RedisConfig.java
@@ -1,0 +1,46 @@
+package com.moyobab.server.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password:}")
+    private String password;
+
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        if (!password.isEmpty()) {
+            config.setPassword(password);
+        }
+        return new LettuceConnectionFactory(config);
+    }
+
+    // RedisTemplate 설정 (Key: String, Value: String 기준으로)
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/moyobab/server/global/util/HmacUtils.java
+++ b/src/main/java/com/moyobab/server/global/util/HmacUtils.java
@@ -1,0 +1,28 @@
+package com.moyobab.server.global.util;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+public class HmacUtils {
+
+    private static final String HMAC_ALGO = "HmacSHA256";
+
+    public static String hmacSha256(String secret, String data) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGO);
+            SecretKeySpec secretKeySpec = new SecretKeySpec(secret.getBytes(), HMAC_ALGO);
+            mac.init(secretKeySpec);
+            byte[] hmacBytes = mac.doFinal(data.getBytes());
+
+            return Base64.getEncoder().encodeToString(hmacBytes);
+        } catch (Exception e) {
+            throw new RuntimeException("HMAC 생성 실패", e);
+        }
+    }
+
+    public static boolean isEqual(String hmac1, String hmac2) {
+        return MessageDigest.isEqual(hmac1.getBytes(), hmac2.getBytes());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #17 

## 📝 작업 내용

- 기존 DB에 저장하던 Refresh Token을 Redis에 저장하도록 로직 변경
- RefreshTokenRedis 서비스 로직으로 Redis에 토큰 저장,조회,삭제 기능 구현
- AuthService 내 로그인, 재발급, 로그아웃 로직에서 레디스 방식으로 수정
- application.yml / docker-compose.yml 설정에 Redis 정보 추가

## 🖼️ 스크린샷 (선택)
### 토큰 Redis 저장
<img width="905" height="492" alt="저장성공" src="https://github.com/user-attachments/assets/341bb19b-e429-4f64-9b2a-9a8f77c0d5a4" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - Docker 및 Docker Compose 지원 추가: 앱, Redis, MySQL을 함께 실행하고 8080 포트로 접근 가능. 데이터 및 로그 영속 볼륨 제공.
  - Redis 기반 리프레시 토큰 저장소 추가 및 Redis 연결 설정 제공.
- 개선
  - 인증 토큰 관리를 Redis로 전환하여 재발급·로그아웃 흐름 간소화 및 일관성 향상.
- 작업
  - 빌드 설정에 Redis 의존성 추가.
  - .gitignore에 환경파일 항목 추가 (.env, application-docker.yml).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->