### PR TITLE
[feat] enum 기반 메뉴 카테고리 조회 테스트 코드 작성 및 API 구현 

### DIFF
--- a/src/main/java/com/moyobab/server/menucategory/controller/MenuCategoryController.java
+++ b/src/main/java/com/moyobab/server/menucategory/controller/MenuCategoryController.java
@@ -1,9 +1,31 @@
 package com.moyobab.server.menucategory.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.moyobab.server.global.response.CommonResponse;
+import com.moyobab.server.menucategory.dto.MenuCategoryResponseDto;
+import com.moyobab.server.menucategory.service.MenuCategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/menu-categories")
 public class MenuCategoryController {
+
+    private final MenuCategoryService menuCategoryService;
+
+    @GetMapping
+    @Operation(summary = "메뉴 카테고리 조회", description = "모든 메뉴 카테고리를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
+    public CommonResponse<List<MenuCategoryResponseDto>> getCategories() {
+        return CommonResponse.success(menuCategoryService.getAllCategories());
+    }
 }

--- a/src/main/java/com/moyobab/server/menucategory/dto/MenuCategoryResponseDto.java
+++ b/src/main/java/com/moyobab/server/menucategory/dto/MenuCategoryResponseDto.java
@@ -1,15 +1,21 @@
 package com.moyobab.server.menucategory.dto;
 
-import lombok.*;
+import com.moyobab.server.menucategory.entity.MenuCategoryType;
+import lombok.Builder;
+import lombok.Getter;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class MenuCategoryResponseDto {
-    private Long id;
     private String name;
-    private String description;
-    private String imageUrl;
+    private String displayName;
+    private String kakaoCategoryKeyword;
+
+    public static MenuCategoryResponseDto from(MenuCategoryType type) {
+        return MenuCategoryResponseDto.builder()
+                .name(type.name())
+                .displayName(type.getDisplayName())
+                .kakaoCategoryKeyword(type.getKakaoCategoryKeyword())
+                .build();
+    }
 }

--- a/src/main/java/com/moyobab/server/menucategory/entity/MenuCategoryType.java
+++ b/src/main/java/com/moyobab/server/menucategory/entity/MenuCategoryType.java
@@ -1,0 +1,30 @@
+package com.moyobab.server.menucategory.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum MenuCategoryType {
+    CHICKEN("치킨", "치킨"),
+    PIZZA("피자", "피자"),
+    KOREAN("한식", "한식"),
+    JAPANESE("일식", "돈까스"),
+    CHINESE("중식", "중국집"),
+    SNACK("분식", "떡볶이"),
+    CAFE("카페/디저트", "카페"),
+    FASTFOOD("패스트푸드", "햄버거"),
+    MEAT("고기", "고깃집"),
+    STEW("찌개/탕", "찌개"),
+    LUNCHBOX("도시락", "도시락"),
+    NIGHT("야식", "야식"),
+    ASIAN("아시안", "베트남음식"),
+    PUB("술집", "호프");
+
+    private final String displayName;
+    private final String kakaoCategoryKeyword; // 카카오 카테고리 검색 외부 api 도입 예정
+
+    MenuCategoryType(String displayName, String kakaoCategoryKeyword) {
+        this.displayName = displayName;
+        this.kakaoCategoryKeyword = kakaoCategoryKeyword;
+    }
+}
+

--- a/src/main/java/com/moyobab/server/menucategory/mapper/MenuCategoryMapper.java
+++ b/src/main/java/com/moyobab/server/menucategory/mapper/MenuCategoryMapper.java
@@ -1,3 +1,4 @@
+/* 지금은 필요 없는 파일 (혹시 나중에 DB 기반 메뉴 카테고리 조회를 써야한다면 그때 사용)
 package com.moyobab.server.menucategory.mapper;
 
 import com.moyobab.server.menucategory.dto.MenuCategoryResponseDto;
@@ -14,3 +15,4 @@ public class MenuCategoryMapper {
                 .build();
     }
 }
+ */

--- a/src/main/java/com/moyobab/server/menucategory/service/MenuCategoryService.java
+++ b/src/main/java/com/moyobab/server/menucategory/service/MenuCategoryService.java
@@ -1,7 +1,18 @@
 package com.moyobab.server.menucategory.service;
 
+import com.moyobab.server.menucategory.dto.MenuCategoryResponseDto;
+import com.moyobab.server.menucategory.entity.MenuCategoryType;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class MenuCategoryService {
+
+    public List<MenuCategoryResponseDto> getAllCategories() {
+        return List.of(MenuCategoryType.values()).stream()
+                .map(MenuCategoryResponseDto::from)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/test/java/com/moyobab/server/menucategory/controller/MenuCategoryControllerTest.java
+++ b/src/test/java/com/moyobab/server/menucategory/controller/MenuCategoryControllerTest.java
@@ -28,7 +28,7 @@ class MenuCategoryControllerTest {
     void getAllMenuCategories() throws Exception {
         ResultActions result = mockMvc.perform(get("/api/v1/menu-categories")
                 .contentType(MediaType.APPLICATION_JSON));
-        
+
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(MenuCategoryType.values().length))

--- a/src/test/java/com/moyobab/server/menucategory/controller/MenuCategoryControllerTest.java
+++ b/src/test/java/com/moyobab/server/menucategory/controller/MenuCategoryControllerTest.java
@@ -1,0 +1,39 @@
+package com.moyobab.server.menucategory.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moyobab.server.menucategory.entity.MenuCategoryType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+class MenuCategoryControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("메뉴 카테고리 전체 조회 - 성공")
+    void getAllMenuCategories() throws Exception {
+        ResultActions result = mockMvc.perform(get("/api/v1/menu-categories")
+                .contentType(MediaType.APPLICATION_JSON));
+        
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(MenuCategoryType.values().length))
+                .andExpect(jsonPath("$.data[0].name").value(MenuCategoryType.values()[0].name()))
+                .andExpect(jsonPath("$.data[0].displayName").value(MenuCategoryType.values()[0].getDisplayName()))
+                .andExpect(jsonPath("$.data[0].kakaoCategoryKeyword").value(MenuCategoryType.values()[0].getKakaoCategoryKeyword()));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #20 

## 📝 작업 내용
1. 카카오 api 연동 전 백엔드에서 구성해놓은 enum을 기반으로 하는 메뉴 카테고리 조회 테스트 코드 구현 (컨트롤러)
2. 메뉴 카테고리 조회 API 구현

## 🖼️ 스크린샷 (선택)
### 메뉴 카테고리 조회 성공
<img width="1448" height="945" alt="성공" src="https://github.com/user-attachments/assets/0170c09a-f8ba-4dd0-9d5a-370dc99776ec" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 메뉴 카테고리 조회 API(GET /api/v1/menu-categories) 추가
  - 전체 카테고리 목록을 반환하며 각 항목은 name, displayName, kakaoCategoryKeyword를 포함
  - 표준 응답 포맷으로 성공 결과 제공

- 테스트
  - 메뉴 카테고리 조회 API에 대한 통합 테스트 추가
  - 응답 상태, 데이터 배열 존재 여부, 항목 수, 필드 값(name/displayName/kakaoCategoryKeyword) 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->