### PR TITLE
[fix] 그룹생성 API 연동 중 발생한 오류들 해결 

### DIFF
--- a/src/main/java/com/moyobab/server/ServerApplication.java
+++ b/src/main/java/com/moyobab/server/ServerApplication.java
@@ -2,10 +2,8 @@ package com.moyobab.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/moyobab/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/moyobab/server/global/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                                 "/api/v1/users/check-email",
                                 "/api/v1/users/check-nickname",
                                 "/api/v1/places/search",
+                                "/api/v1/group-orders/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"
                         ).permitAll()

--- a/src/main/java/com/moyobab/server/grouporder/dto/GroupOrderResponseDto.java
+++ b/src/main/java/com/moyobab/server/grouporder/dto/GroupOrderResponseDto.java
@@ -15,4 +15,6 @@ public class GroupOrderResponseDto {
     private int maxDistance;
     private String deadlineTime;
     private boolean closed;
+    private int currentOrderAmount;
+    private String creatorNickname;
 }

--- a/src/main/java/com/moyobab/server/grouporder/entity/GroupOrder.java
+++ b/src/main/java/com/moyobab/server/grouporder/entity/GroupOrder.java
@@ -1,11 +1,13 @@
 package com.moyobab.server.grouporder.entity;
 
 import com.moyobab.server.global.entity.BaseEntity;
+import com.moyobab.server.participant.entity.Participant;
 import com.moyobab.server.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -33,4 +35,7 @@ public class GroupOrder extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creator_id", nullable = false)
     private User creator;
+
+    @OneToMany(mappedBy = "groupOrder")
+    private List<Participant> participants;
 }

--- a/src/main/java/com/moyobab/server/grouporder/mapper/GroupOrderMapper.java
+++ b/src/main/java/com/moyobab/server/grouporder/mapper/GroupOrderMapper.java
@@ -19,6 +19,8 @@ public class GroupOrderMapper {
                 .maxDistance(groupOrder.getMaxDistance())
                 .deadlineTime(groupOrder.getDeadlineTime().format(formatter))
                 .closed(groupOrder.isClosed())
+                .currentOrderAmount(0)
+                .creatorNickname(groupOrder.getCreator().getNickname())
                 .build();
     }
 }

--- a/src/main/java/com/moyobab/server/grouporder/mapper/GroupOrderMapper.java
+++ b/src/main/java/com/moyobab/server/grouporder/mapper/GroupOrderMapper.java
@@ -11,6 +11,14 @@ public class GroupOrderMapper {
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     public static GroupOrderResponseDto toResponse(GroupOrder groupOrder) {
+        // 현재 참여한 사람들의 주문 금액 합계 계산
+        int totalOrderAmount = 0;
+        if (groupOrder.getParticipants() != null) {
+            totalOrderAmount = groupOrder.getParticipants().stream()
+                    .mapToInt(participant -> participant.getOrderAmount().intValue())
+                    .sum();
+        }
+
         return GroupOrderResponseDto.builder()
                 .id(groupOrder.getId())
                 .menuCategory(groupOrder.getMenuCategory())
@@ -19,7 +27,7 @@ public class GroupOrderMapper {
                 .maxDistance(groupOrder.getMaxDistance())
                 .deadlineTime(groupOrder.getDeadlineTime().format(formatter))
                 .closed(groupOrder.isClosed())
-                .currentOrderAmount(0)
+                .currentOrderAmount(totalOrderAmount)
                 .creatorNickname(groupOrder.getCreator().getNickname())
                 .build();
     }

--- a/src/main/java/com/moyobab/server/grouporder/repository/GroupOrderRepository.java
+++ b/src/main/java/com/moyobab/server/grouporder/repository/GroupOrderRepository.java
@@ -1,10 +1,12 @@
 package com.moyobab.server.grouporder.repository;
 
 import com.moyobab.server.grouporder.entity.GroupOrder;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface GroupOrderRepository extends JpaRepository<GroupOrder, Long> {
+    @EntityGraph(attributePaths = {"participants", "creator"})
     List<GroupOrder> findAllByClosedFalseOrderByDeadlineTimeAsc();  // 모집 중 + 마감 임박순 정렬
 }

--- a/src/main/java/com/moyobab/server/participant/entity/Participant.java
+++ b/src/main/java/com/moyobab/server/participant/entity/Participant.java
@@ -1,6 +1,7 @@
 package com.moyobab.server.participant.entity;
 
 import com.moyobab.server.global.entity.BaseEntity;
+import com.moyobab.server.grouporder.entity.GroupOrder;
 import com.moyobab.server.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -17,8 +18,6 @@ public class Participant extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long groupOrderId; // 참여한 그룹 주문 ID
-
     @Column(nullable = false)
     private Long orderAmount; // 해당 유저가 주문한 금액(원)
 
@@ -29,4 +28,8 @@ public class Participant extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_order_id", nullable = false)
+    private GroupOrder groupOrder;
 }

--- a/src/main/java/com/moyobab/server/participant/mapper/ParticipantMapper.java
+++ b/src/main/java/com/moyobab/server/participant/mapper/ParticipantMapper.java
@@ -8,7 +8,7 @@ public class ParticipantMapper {
     public static ParticipantResponseDto toResponse(Participant participant) {
         return ParticipantResponseDto.builder()
                 .id(participant.getId())
-                .groupOrderId(participant.getGroupOrderId())
+                .groupOrderId(participant.getGroupOrder().getId())
                 .orderAmount(participant.getOrderAmount())
                 .paid(participant.isPaid())
                 .build();

--- a/src/main/java/com/moyobab/server/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/moyobab/server/participant/repository/ParticipantRepository.java
@@ -1,10 +1,12 @@
 package com.moyobab.server.participant.repository;
 
 import com.moyobab.server.participant.entity.Participant;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+    @EntityGraph(attributePaths = {"groupOrder"})
     List<Participant> findByGroupOrderId(Long groupOrderId);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #27 

## 📝 작업 내용
1. 프론트와 타입 맞추기 위해 DTO에 currentOrderAmount, creatorNickname; 추가
2. @EnableJpaAuditing 중복으로 서버 안열리던 문제 해결
3. 그룹 생성 엔티티에 참여자 목록 관련 연관관계 추가 
4. 레포지토리에 @EntityGraph 추가하여 Lazy 로딩 문제로 프론트 연동 시 오류 발생하던 문제 해결 

## 🖼️ 스크린샷 (선택)
### 프론트 그룹생성 API 연동 성공
<img width="1295" height="825" alt="그룹생성연동성공" src="https://github.com/user-attachments/assets/ec540d74-257c-4b6b-bd28-36f908af5764" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그룹 주문 API 엔드포인트(`/api/v1/group-orders/**`)가 인증 없이 공개적으로 접근 가능하게 변경되었습니다.

* **개선사항**
  * 그룹 주문 응답에 현재 주문 총액과 생성자 닉네임 정보가 추가되었습니다.
  * 데이터 조회 성능 최적화를 통해 관련 정보를 효율적으로 로드합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->